### PR TITLE
chore: use caret version range in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         "filp/whoops": "^2.1.4",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
         "scrivo/highlight.php": "^9.15",
-        "symfony/var-dumper": "^3.4|~4.0",
-        "symfony/console": "^3.4|~4.0",
-        "monolog/monolog": "~1.12",
-        "facade/flare-client-php": "~1.0",
-        "facade/ignition-contracts": "~1.0",
+        "symfony/var-dumper": "^3.4|^4.0",
+        "symfony/console": "^3.4|^4.0",
+        "monolog/monolog": "^1.12",
+        "facade/flare-client-php": "^1.0",
+        "facade/ignition-contracts": "^1.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request makes the file `composer.json` a little bit more clear using `Caret Version Range` by default.