### PR TITLE
chore: adds missing extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "monolog/monolog": "^1.12",
         "facade/flare-client-php": "^1.0",
         "facade/ignition-contracts": "^1.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",


### PR DESCRIPTION
The class `Facade\Ignition\Views\Compilers\BladeSourceMapCompiler` is using `mb_substr`, therefore ignition needs `ext-mbstring` extension. 