### PR TITLE
Update the readme to fix #14 and update the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ignition
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/facade/flare.svg?style=flat-square)](https://packagist.org/packages/facade/flare)
-[![Build Status](https://img.shields.io/circleci/build/gh/spatie/flare/master.svg?token=8fa8ce4d514d525bdab557f351df1afc2f6b1720&style=flat-square)](https://circleci.com/gh/spatie/workflows/flare)
-[![Quality Score](https://img.shields.io/scrutinizer/g/facade/flare.svg?style=flat-square)](https://scrutinizer-ci.com/g/facade/flare)
-[![Total Downloads](https://img.shields.io/packagist/dt/facade/flare.svg?style=flat-square)](https://packagist.org/packages/facade/flare)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/facade/ignition.svg?style=flat-square)](https://packagist.org/packages/facade/ignition)
+[![Build Status](https://img.shields.io/circleci/build/gh/facade/ignition/master.svg?token=8fa8ce4d514d525bdab557f351df1afc2f6b1720&style=flat-square)](https://circleci.com/gh/facade/workflows/ignition)
+[![Quality Score](https://img.shields.io/scrutinizer/g/facade/ignition.svg?style=flat-square)](https://scrutinizer-ci.com/g/facade/ignition)
+[![Total Downloads](https://img.shields.io/packagist/dt/facade/ignition.svg?style=flat-square)](https://packagist.org/packages/facade/ignition)
 
 Ignition offers you a beautiful, customizable error screen. It also allows you to share your errors to Flare publicly. 
 If configured with a valid Flare API key, it will send errors to a project in your Flare account.


### PR DESCRIPTION
At the moment the scrutinizer and the circleci badges 404 because those projects don't seem to be set up. 

I'm leaving them there and making the assumption that the wonderful folks who own this project will set those up. If there are no plans to set up either of those projects I'll be happy to remove the badges from this PR.