### PR TITLE
Add support for L5.5 & 5.6

### DIFF
--- a/src/ErrorPage/ErrorPageViewModel.php
+++ b/src/ErrorPage/ErrorPageViewModel.php
@@ -96,7 +96,11 @@ class ErrorPageViewModel implements Arrayable
 
     protected function shareEndpoint()
     {
-        return action([ShareReportController::class]);
+        // In L5.5 and 5.6 `action` doesn't accept callable syntax, so we crash.
+        // Swap back to the uglier syntax until 5.5 & 5.6 support is removed.
+        // The same change is not needed for telescope action call above as telescope
+        // min version is 5.7, so it's not an issue there.
+        return action('\Facade\Ignition\Http\Controllers\ShareReportController');
     }
 
     public function report(): array


### PR DESCRIPTION
The [docs](https://flareapp.io/docs/ignition-for-laravel/installation) currently list support for Laravel versions 5.5 and 5.6, but because of a dependency on callable array syntax functionality in the `action` function, any error triggered on a 5.5 or 5.6 app falls back to the old-style `whoops` screen (https://github.com/facade/ignition/issues/20).

This PR changes the `action` call into the `ShareReportController` to the uglier, older style until such a time as support for 5.5 and 5.6 is officially dropped.

There's a similar `action()` call in this file also relying on the callable syntax, for telescope logging. That has been left alone here - it doesn't need to change as telescope itself has a minimum version of 5.7, where this problem no longer exists.