### PR TITLE
Suggest default database name in Laravel 6

### DIFF
--- a/src/SolutionProviders/DefaultDbNameSolutionProvider.php
+++ b/src/SolutionProviders/DefaultDbNameSolutionProvider.php
@@ -15,7 +15,7 @@ class DefaultDbNameSolutionProvider implements HasSolutionsForThrowable
             try {
                 DB::connection()->select('SELECT 1');
             } catch (\Exception $e) {
-                return env('DB_DATABASE') === 'homestead';
+                return in_array(env('DB_DATABASE'), ['homestead', 'laravel']);
             }
         }
 


### PR DESCRIPTION
I created a new L6 app and the default database is `laravel` not `homestead` and Ignition didn't suggest the fix to me.