### PR TITLE
Add void return type to FlareHandler::write()

### DIFF
--- a/src/Logger/FlareHandler.php
+++ b/src/Logger/FlareHandler.php
@@ -21,7 +21,7 @@ class FlareHandler extends AbstractProcessingHandler
         parent::__construct($level, $bubble);
     }
 
-    protected function write(array $report)
+    protected function write(array $report): void
     {
         if ($this->shouldReport($report)) {
 


### PR DESCRIPTION
The FlareHandler class throws an exception because the abstract class `Monolog\Handler\AbstractProcessingHandler` defines return type `void` for the `write()` function and `Facade\Ignition\Logger\FlareHandler`  does not.

```
   Symfony\Component\Debug\Exception\FatalErrorException  : Declaration of Facade\Ignition\Logger\FlareHandler::write(array $report) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void

  at .../vendor/facade/ignition/src/Logger/FlareHandler.php:12
     8| use Facade\Ignition\Ignition;
     9| use Facade\Ignition\Tabs\Tab;
    10| use Monolog\Handler\AbstractProcessingHandler;
    11| 
  > 12| class FlareHandler extends AbstractProcessingHandler
    13| {
    14|     /** @var \Facade\FlareClient\Flare */
    15|     protected $flare;
    16| 
```

Package versions: 

- Ignition 1.4.3
- Laravel 6.0.0
- Monolog 2.0.0