### PR TITLE
On first run after upgrading an application to Laravel 6, error

### DIFF
--- a/src/IgnitionConfig.php
+++ b/src/IgnitionConfig.php
@@ -66,6 +66,6 @@ class IgnitionConfig implements Arrayable
 
     protected function mergeWithDefaultConfig(array $options = []): array
     {
-        return array_merge(config('ignition'), $options);
+        return array_merge(config('ignition') ? : include __DIR__.'/../config/ignition.php', $options);
     }
 }


### PR DESCRIPTION
It will throw an exception on this line.

"The bug": If you don't run vendor publication of the default configs, this will throw an error rendering the page with the default symfony debugger.

No need to merge this exactly, but it solves the problem :)