### PR TITLE
Lookup the first exception entry when linking to Telescope

### DIFF
--- a/src/ErrorPage/ErrorPageViewModel.php
+++ b/src/ErrorPage/ErrorPageViewModel.php
@@ -10,6 +10,7 @@ use Facade\FlareClient\Report;
 use Laravel\Telescope\Telescope;
 use Facade\Ignition\IgnitionConfig;
 use Illuminate\Contracts\Support\Arrayable;
+use Laravel\Telescope\IncomingExceptionEntry;
 use Facade\Ignition\Solutions\SolutionTransformer;
 use Laravel\Telescope\Http\Controllers\HomeController;
 
@@ -61,7 +62,15 @@ class ErrorPageViewModel implements Arrayable
                 return '';
             }
 
-            $telescopeEntryId = (string) Telescope::$entriesQueue[0]->uuid;
+            $telescopeEntry = collect(Telescope::$entriesQueue)->first(function ($entry) {
+                return $entry instanceof IncomingExceptionEntry;
+            });
+
+            if (is_null($telescopeEntry)) {
+                return '';
+            }
+
+            $telescopeEntryId = (string) $telescopeEntry->uuid;
 
             return url(action([HomeController::class, 'index'])."/exceptions/{$telescopeEntryId}");
         } catch (Exception $exception) {

--- a/src/ErrorPage/ErrorPageViewModel.php
+++ b/src/ErrorPage/ErrorPageViewModel.php
@@ -55,11 +55,11 @@ class ErrorPageViewModel implements Arrayable
     {
         try {
             if (! class_exists(Telescope::class)) {
-                return '';
+                return null;
             }
 
             if (! count(Telescope::$entriesQueue)) {
-                return '';
+                return null;
             }
 
             $telescopeEntry = collect(Telescope::$entriesQueue)->first(function ($entry) {
@@ -67,14 +67,14 @@ class ErrorPageViewModel implements Arrayable
             });
 
             if (is_null($telescopeEntry)) {
-                return '';
+                return null;
             }
 
             $telescopeEntryId = (string) $telescopeEntry->uuid;
 
             return url(action([HomeController::class, 'index'])."/exceptions/{$telescopeEntryId}");
         } catch (Exception $exception) {
-            return '';
+            return null;
         }
     }
 


### PR DESCRIPTION
Right now we simply use the first entry that is in the Telescope entry queue. This might not be the correct one though, as other entries could be there - like logs or queues.

This PR fixes this by checking that the entry is for an exception.