### PR TITLE
Remove quotation from git commitUrl

### DIFF
--- a/resources/js/components/Tabs/ContextTab.vue
+++ b/resources/js/components/Tabs/ContextTab.vue
@@ -117,7 +117,7 @@ export default {
         },
 
         commitUrl() {
-            return `${this.repoUrl}/commit/${this.git.hash}`;
+            return `${this.repoUrl}/commit/${this.git.hash.replace(/'/g, '')}`;
         },
 
         tagUrl() {


### PR DESCRIPTION
Remove quotation from git commitUrl on Git Context Tab.