### PR TITLE
Use a middleware to protect ignition routes

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -89,4 +89,17 @@ return [
     'remote_sites_path' => env('IGNITION_REMOTE_SITES_PATH', ''),
     'local_sites_path' => env('IGNITION_LOCAL_SITES_PATH', ''),
 
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Housekeeping Endpoint Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Ignition registers a couple of routes if it is enabled. Here you can define
+    | the route prefix it should use.
+    |
+    */
+    'housekeeping_endpoint_prefix' => '_ignition',
+
 ];

--- a/src/ErrorPage/ErrorPageViewModel.php
+++ b/src/ErrorPage/ErrorPageViewModel.php
@@ -147,7 +147,7 @@ class ErrorPageViewModel implements Arrayable
             'config' => $this->config(),
             'solutions' => $this->solutions(),
             'report' => $this->report(),
-            'housekeepingEndpoint' => config('flare.housekeeping_endpoint_prefix', 'flare'),
+            'housekeepingEndpoint' => config('ignition.housekeeping_endpoint_prefix', '_ignition'),
             'styles' => $this->styles(),
             'scripts' => $this->scripts(),
             'tabs' => $this->tabs(),

--- a/src/Http/Middleware/IgnitionEnabled.php
+++ b/src/Http/Middleware/IgnitionEnabled.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Facade\Ignition\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class IgnitionEnabled
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $this->ignitionEnabled()) {
+            abort(404);
+        }
+
+        return $next($request);
+
+    }
+
+    protected function ignitionEnabled(): bool
+    {
+        return config('app.debug');
+    }
+}

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Facade\Ignition;
 
+use Facade\Ignition\Http\Middleware\IgnitionEnabled;
 use Monolog\Logger;
 use Illuminate\Support\Arr;
 use Facade\FlareClient\Flare;
@@ -117,19 +118,17 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function registerHousekeepingRoutes()
     {
-        if (! config('app.debug')) {
-            return $this;
-        }
+        Route::group([
+            'prefix' => config('ignition.housekeeping_endpoint_prefix', '_ignition'),
+            'middleware' => [IgnitionEnabled::class],
+        ], function () {
+            Route::get('health-check', HealthCheckController::class);
+            Route::post('execute-solution', ExecuteSolutionController::class);
+            Route::post('share-report', ShareReportController::class);
 
-        Route::prefix(config('flare.housekeeping_endpoint_prefix', 'flare'))
-            ->group(function () {
-                Route::get('health-check', HealthCheckController::class);
-                Route::post('execute-solution', ExecuteSolutionController::class);
-                Route::post('share-report', ShareReportController::class);
-
-                Route::get('scripts/{script}', ScriptController::class);
-                Route::get('styles/{style}', StyleController::class);
-            });
+            Route::get('scripts/{script}', ScriptController::class);
+            Route::get('styles/{style}', StyleController::class);
+        });
 
         return $this;
     }

--- a/tests/Http/Middleware/IgnitionEnabledTest.php
+++ b/tests/Http/Middleware/IgnitionEnabledTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Facade\Ignition\Tests\Http\Middleware;
+
+use Facade\Ignition\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Facade\Ignition\Http\Middleware\IgnitionEnabled;
+
+class IgnitionEnabledTest extends TestCase
+{
+    /** @test */
+    public function it_returns_404_with_debug_mode_disabled()
+    {
+        $this->app['config']['app.debug'] = false;
+
+        Route::get('middleware-test', function () {
+            return 'success';
+        })->middleware([IgnitionEnabled::class]);
+
+        $this->get('middleware-test')->assertNotFound();
+    }
+
+    /** @test */
+    public function it_returns_ok_with_debug_mode_enabled()
+    {
+        $this->app['config']['app.debug'] = true;
+
+        Route::get('middleware-test', function () {
+            return 'success';
+        })->middleware([IgnitionEnabled::class]);
+
+        $this->get('middleware-test')->assertOk();
+    }
+}

--- a/tests/Http/Middleware/IgnitionEnabledTest.php
+++ b/tests/Http/Middleware/IgnitionEnabledTest.php
@@ -17,7 +17,7 @@ class IgnitionEnabledTest extends TestCase
             return 'success';
         })->middleware([IgnitionEnabled::class]);
 
-        $this->get('middleware-test')->assertNotFound();
+        $this->get('middleware-test')->assertStatus(404);
     }
 
     /** @test */
@@ -29,6 +29,6 @@ class IgnitionEnabledTest extends TestCase
             return 'success';
         })->middleware([IgnitionEnabled::class]);
 
-        $this->get('middleware-test')->assertOk();
+        $this->get('middleware-test')->assertStatus(200);
     }
 }


### PR DESCRIPTION
By always registering our routes we avoid issues like #87 
The middleware then takes care of choosing whether or not the route should be reachable.