### PR TITLE
Use HTTPS link for Gravatar

### DIFF
--- a/resources/js/components/Tabs/UserTab.vue
+++ b/resources/js/components/Tabs/UserTab.vue
@@ -46,7 +46,7 @@ export default {
 
             const size = 80;
 
-            return 'http://www.gravatar.com/avatar/' + md5(this.user.email) + '.jpg?s=' + size;
+            return 'https://www.gravatar.com/avatar/' + md5(this.user.email) + '.jpg?s=' + size;
         },
 
         stringifiedUserData() {


### PR DESCRIPTION
Prevent mixed content warnings

`Mixed Content: The page at 'https://flareapp.io/occurrence/XXXXXX' was loaded over HTTPS, but requested an insecure image 'http://www.gravatar.com/avatar/XXXXXX.jpg?s=80'. This content should also be served over HTTPS.`