### PR TITLE
build all Laravel versions on php 7.4snapshot and allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,12 +89,13 @@ matrix:
     - php: 7.4snapshot
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
 
-before_script:
-    - composer config discard-changes true
-
 before_install:
+  - composer config discard-changes true
   - travis_retry composer self-update
   - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
 
 install:
   - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
+
+script:
+  - vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,6 @@ matrix:
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-  fast_finish: true
-  allow_failures:
     - php: 7.4snapshot
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4snapshot
@@ -88,6 +86,9 @@ matrix:
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4snapshot
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+  fast_finish: true
+  allow_failures:
+    - php: 7.4snapshot
 
 before_install:
   - composer config discard-changes true

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,27 @@ matrix:
     - php: 7.3
       env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
   fast_finish: true
+  allow_failures:
+    - php: 7.4snapshot
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4snapshot
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4snapshot
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4snapshot
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4snapshot
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4snapshot
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4snapshot
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
 
 before_script:
     - composer config discard-changes true


### PR DESCRIPTION
This PR adds all Laravel versions in lowest and stable config and PHP 7.4 snapshot to the build matrix and allows failures. 