### PR TITLE
Fix registering multiple solution providers

### DIFF
--- a/src/SolutionProviders/SolutionProviderRepository.php
+++ b/src/SolutionProviders/SolutionProviderRepository.php
@@ -28,7 +28,7 @@ class SolutionProviderRepository implements SolutionProviderRepositoryContract
 
     public function registerSolutionProviders(array $solutionProviderClasses): SolutionProviderRepositoryContract
     {
-        $this->solutionProviders->merge($solutionProviderClasses);
+        $this->solutionProviders = $this->solutionProviders->merge($solutionProviderClasses);
 
         return $this;
     }

--- a/tests/ExceptionSolutionTest.php
+++ b/tests/ExceptionSolutionTest.php
@@ -29,6 +29,23 @@ class ExceptionSolutionTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_possible_solutions_when_registered_together()
+    {
+        $repository = new SolutionProviderRepository();
+
+        $repository->registerSolutionProviders([
+            AlwaysTrueSolutionProvider::class,
+            AlwaysFalseSolutionProvider::class,
+        ]);
+
+        $solutions = $repository->getSolutionsForThrowable(new \Exception());
+
+        $this->assertNotNull($solutions);
+        $this->assertCount(1, $solutions);
+        $this->assertTrue($solutions[0] instanceof BaseSolution);
+    }
+
+    /** @test */
     public function it_can_ignore_solution_providers()
     {
         $this->app->make('config')->set('ignition.ignored_solution_providers', [


### PR DESCRIPTION
When using `registerSolutionProviders`, nothing was happening because the property wasn't being set.