### PR TITLE
Cross-platform PHPStorm editor URL

### DIFF
--- a/resources/js/components/Shared/editorUrl.js
+++ b/resources/js/components/Shared/editorUrl.js
@@ -5,7 +5,7 @@ export default function editorUrl(config, file, lineNumber) {
         textmate: 'txmt://open?url=file://%path&line=%line',
         emacs: 'emacs://open?url=file://%path&line=%line',
         macvim: 'mvim://open/?url=file://%path&line=%line',
-        phpstorm: 'phpstorm://open?file=%path&line=%line',
+        phpstorm: 'http://localhost:63342/api/file/?file=%path&line=%line',
         idea: 'idea://open?file=%path&line=%line',
         vscode: 'vscode://file/%path:%line',
         'vscode-insiders': 'vscode-insiders://file/%path:%line',


### PR DESCRIPTION
Resolves #33 #104 

This solution was tested in Laravel Whoops Editor package:
https://github.com/cybercog/laravel-whoops-editor/blob/master/config/whoops-editor.php#L48

PHPStorm fix:
```
http://localhost:63342/api/file/?file=%path&line=%line
```