### PR TITLE
Add RouteNotDefined Solution Provider

### DIFF
--- a/src/SolutionProviders/RouteNotDefinedSolutionProvider.php
+++ b/src/SolutionProviders/RouteNotDefinedSolutionProvider.php
@@ -6,8 +6,8 @@ use Throwable;
 use InvalidArgumentException;
 use Illuminate\Support\Facades\Route;
 use Facade\IgnitionContracts\BaseSolution;
-use Facade\Ignition\Support\StringComparator;
 use Facade\Ignition\Exceptions\ViewException;
+use Facade\Ignition\Support\StringComparator;
 use Facade\IgnitionContracts\HasSolutionsForThrowable;
 
 class RouteNotDefinedSolutionProvider implements HasSolutionsForThrowable
@@ -50,5 +50,4 @@ class RouteNotDefinedSolutionProvider implements HasSolutionsForThrowable
 
         return StringComparator::findClosestMatch(array_keys(Route::getRoutes()->getRoutesByName()), $missingRoute);
     }
-
 }

--- a/src/SolutionProviders/RouteNotDefinedSolutionProvider.php
+++ b/src/SolutionProviders/RouteNotDefinedSolutionProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Facade\Ignition\SolutionProviders;
+
+use Throwable;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\Route;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\Ignition\Support\StringComparator;
+use Facade\Ignition\Exceptions\ViewException;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+
+class RouteNotDefinedSolutionProvider implements HasSolutionsForThrowable
+{
+    protected const REGEX = '/Route \[(.*)\] not defined/m';
+
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof InvalidArgumentException && ! $throwable instanceof ViewException) {
+            return false;
+        }
+
+        return preg_match(self::REGEX, $throwable->getMessage(), $matches);
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        preg_match(self::REGEX, $throwable->getMessage(), $matches);
+
+        $missingRoute = $matches[1] ?? null;
+
+        $suggestedRoute = $this->findRelatedRoute($missingRoute);
+
+        if ($suggestedRoute) {
+            return [
+                BaseSolution::create("{$missingRoute} was not defined.")
+                    ->setSolutionDescription("Did you mean `{$suggestedRoute}`?"),
+            ];
+        }
+
+        return [
+            BaseSolution::create("{$missingRoute} was not defined.")
+                ->setSolutionDescription('Are you sure that the route is defined'),
+        ];
+    }
+
+    protected function findRelatedRoute(string $missingRoute): ?string
+    {
+        Route::getRoutes()->refreshNameLookups();
+
+        return StringComparator::findClosestMatch(array_keys(Route::getRoutes()->getRoutesByName()), $missingRoute);
+    }
+
+}

--- a/tests/Solutions/RouteNotDefinedSolutionProviderTest.php
+++ b/tests/Solutions/RouteNotDefinedSolutionProviderTest.php
@@ -21,7 +21,7 @@ class RouteNotDefinedSolutionProviderTest extends TestCase
     /** @test */
     public function it_can_recommend_changing_the_route_name()
     {
-        Route::get('/test','TestController@typo')->name('test.typo');
+        Route::get('/test', 'TestController@typo')->name('test.typo');
 
         /** @var \Facade\IgnitionContracts\Solution $solution */
         $solution = app(RouteNotDefinedSolutionProvider::class)->getSolutions($this->getRouteNotDefinedException())[0];
@@ -32,7 +32,7 @@ class RouteNotDefinedSolutionProviderTest extends TestCase
     /** @test */
     public function it_wont_recommend_another_route_if_the_names_are_too_different()
     {
-        Route::get('/test','TestController@typo')->name('test.typo');
+        Route::get('/test', 'TestController@typo')->name('test.typo');
 
         /** @var \Facade\IgnitionContracts\Solution $solution */
         $solution = app(RouteNotDefinedSolutionProvider::class)->getSolutions($this->getRouteNotDefinedException('test.is-too-different'))[0];

--- a/tests/Solutions/RouteNotDefinedSolutionProviderTest.php
+++ b/tests/Solutions/RouteNotDefinedSolutionProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Facade\Ignition\Tests\Solutions;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Facade\Ignition\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Facade\Ignition\SolutionProviders\RouteNotDefinedSolutionProvider;
+
+class RouteNotDefinedSolutionProviderTest extends TestCase
+{
+    /** @test */
+    public function it_can_solve_the_exception()
+    {
+        $canSolve = app(RouteNotDefinedSolutionProvider::class)->canSolve($this->getRouteNotDefinedException());
+
+        $this->assertTrue($canSolve);
+    }
+
+    /** @test */
+    public function it_can_recommend_changing_the_route_name()
+    {
+        Route::get('/test','TestController@typo')->name('test.typo');
+
+        /** @var \Facade\IgnitionContracts\Solution $solution */
+        $solution = app(RouteNotDefinedSolutionProvider::class)->getSolutions($this->getRouteNotDefinedException())[0];
+
+        $this->assertTrue(Str::contains($solution->getSolutionDescription(), 'Did you mean `test.typo`?'));
+    }
+
+    /** @test */
+    public function it_wont_recommend_another_route_if_the_names_are_too_different()
+    {
+        Route::get('/test','TestController@typo')->name('test.typo');
+
+        /** @var \Facade\IgnitionContracts\Solution $solution */
+        $solution = app(RouteNotDefinedSolutionProvider::class)->getSolutions($this->getRouteNotDefinedException('test.is-too-different'))[0];
+
+        $this->assertFalse(Str::contains($solution->getSolutionDescription(), 'Did you mean'));
+    }
+
+    protected function getRouteNotDefinedException(string $route = 'test.typoo'): InvalidArgumentException
+    {
+        return new InvalidArgumentException("Route [{$route}] not defined.");
+    }
+}


### PR DESCRIPTION
this **PR** adds a new solution provider for Route Not Defined exceptions. for example when misspilling  `route('posts.something')`

![Screenshot from 2019-09-06 02-59-59](https://user-images.githubusercontent.com/17250137/64393666-c99e4800-d052-11e9-8c93-e2e546f0e618.png)
