### PR TITLE
Add redis client was not installed sollution

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -49,6 +49,7 @@ use Facade\Ignition\SolutionProviders\TableNotFoundSolutionProvider;
 use Illuminate\View\Engines\CompilerEngine as LaravelCompilerEngine;
 use Facade\Ignition\SolutionProviders\MissingPackageSolutionProvider;
 use Facade\Ignition\SolutionProviders\InvalidRouteActionSolutionProvider;
+use Facade\Ignition\SolutionProviders\RedisClientNotInstalledSolutionProvider;
 use Facade\Ignition\SolutionProviders\IncorrectValetDbCredentialsSolutionProvider;
 use Facade\IgnitionContracts\SolutionProviderRepository as SolutionProviderRepositoryContract;
 
@@ -302,6 +303,7 @@ class IgnitionServiceProvider extends ServiceProvider
             InvalidRouteActionSolutionProvider::class,
             ViewNotFoundSolutionProvider::class,
             MergeConflictSolutionProvider::class,
+            RedisClientNotInstalledSolutionProvider::class,
         ];
     }
 

--- a/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
+++ b/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
@@ -18,11 +18,10 @@ class RedisClientNotInstalledSolutionProvider implements HasSolutionsForThrowabl
         return true;
     }
 
-
     public function getSolutions(Throwable $throwable): array
     {
         $client = config('database.redis.client');
-        list($message, $description) = $this->getSolutionMessage($client);
+        [$message, $description] = $this->getSolutionMessage($client);
 
         return [
             BaseSolution::create($message)

--- a/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
+++ b/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Facade\Ignition\SolutionProviders;
+
+use Throwable;
+use Illuminate\Support\Arr;
+use LogicException;
+use Illuminate\Support\Facades\View;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\Ignition\Exceptions\ViewException;
+use Facade\Ignition\Support\StringComparator;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+
+class RedisClientNotInstalledSolutionProvider implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof LogicException && ! $throwable instanceof ViewException) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        $client = config('database.redis.client');
+        list($message, $description) = $this->getSolutionMessage($client);
+
+        return [
+            BaseSolution::create($message)
+                ->setSolutionDescription($description),
+        ];
+    }
+
+    protected function getSolutionMessage(string $client): array
+    {
+        $predis = file_exists(base_path('vendor/predis/predis'));
+        $phpredis = file_exists(base_path('vendor/phpredis/phpredis'));
+
+        if ($client === 'predis') {
+            if ($predis === false && $phpredis === true) {
+                return [
+                    'predis is set as client, but it wasn\'t installed.',
+                    'either run `composer require predis/predis` or default to phpredis which is installed',
+                ];
+            }
+        }
+
+        if ($predis === true && $phpredis === false) {
+            return [
+                'phpredis is set as client, but it wasn\'t installed.',
+                'either run `composer require phpredis/phpredis` or set the `REDIS_CLIENT` to predis in your `.env`.',
+            ];
+        }
+
+        return [
+            'there was no client installed.',
+            'run `composer require phpredis/phpredis`',
+        ];
+    }
+}

--- a/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
+++ b/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
@@ -3,14 +3,8 @@
 namespace Facade\Ignition\SolutionProviders;
 
 use Throwable;
-use Illuminate\Support\Arr;
 use LogicException;
-use Illuminate\Support\Facades\View;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 use Facade\IgnitionContracts\BaseSolution;
-use Facade\Ignition\Exceptions\ViewException;
-use Facade\Ignition\Support\StringComparator;
 use Facade\IgnitionContracts\HasSolutionsForThrowable;
 
 class RedisClientNotInstalledSolutionProvider implements HasSolutionsForThrowable

--- a/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
+++ b/src/SolutionProviders/RedisClientNotInstalledSolutionProvider.php
@@ -11,7 +11,7 @@ class RedisClientNotInstalledSolutionProvider implements HasSolutionsForThrowabl
 {
     public function canSolve(Throwable $throwable): bool
     {
-        if (! $throwable instanceof LogicException && ! $throwable instanceof ViewException) {
+        if (! $throwable instanceof LogicException) {
             return false;
         }
 


### PR DESCRIPTION
In response to my own experience with a redis client mismatch between config and what was installed and also in response to this [tweet](https://twitter.com/freekmurze/status/1170080942716792832) which describes the same.

This PR adds a solution for the redis client mismatch between the config and what is installed.
It does so by checking the config for the redis client which is used and if that client is present in the vendor directory.