### PR TITLE
added solution for running Laravel Dusk in production

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -51,6 +51,7 @@ use Facade\Ignition\SolutionProviders\TableNotFoundSolutionProvider;
 use Illuminate\View\Engines\CompilerEngine as LaravelCompilerEngine;
 use Facade\Ignition\SolutionProviders\MissingPackageSolutionProvider;
 use Facade\Ignition\SolutionProviders\InvalidRouteActionSolutionProvider;
+use Facade\Ignition\SolutionProviders\RunningLaravelDuskInProductionProvider;
 use Facade\Ignition\SolutionProviders\IncorrectValetDbCredentialsSolutionProvider;
 use Facade\IgnitionContracts\SolutionProviderRepository as SolutionProviderRepositoryContract;
 
@@ -308,6 +309,7 @@ class IgnitionServiceProvider extends ServiceProvider
             InvalidRouteActionSolutionProvider::class,
             ViewNotFoundSolutionProvider::class,
             MergeConflictSolutionProvider::class,
+            RunningLaravelDuskInProductionProvider::class,
             MissingColumnSolutionProvider::class,
         ];
     }

--- a/src/SolutionProviders/RunningLaravelDuskInProductionProvider.php
+++ b/src/SolutionProviders/RunningLaravelDuskInProductionProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Facade\Ignition\SolutionProviders;
+
+use Exception;
+use Throwable;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+
+class RunningLaravelDuskInProductionProvider implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof Exception) {
+            return false;
+        }
+
+        return $throwable->getMessage() === 'It is unsafe to run Dusk in production.';
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            BaseSolution::create('Laravel Dusk should not be run in production.')
+                ->setSolutionDescription('Install the dependencies with the `--no-dev` flag.'),
+            BaseSolution::create('Laravel Dusk can be run in other environments.')
+                ->setSolutionDescription('Consider setting the `APP_ENV` to something other than `production` like `local` for example.'),
+        ];
+    }
+}

--- a/tests/Solutions/RunningLaravelDuskInProductionSolutionProviderTest.php
+++ b/tests/Solutions/RunningLaravelDuskInProductionSolutionProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Facade\Ignition\Tests\Solutions;
+
+use Exception;
+use Facade\Ignition\Tests\TestCase;
+use Facade\Ignition\SolutionProviders\RunningLaravelDuskInProductionProvider;
+
+class RunningLaravelDuskInProductionSolutionProviderTest extends TestCase
+{
+    /** @test */
+    public function it_can_solve_dusk_in_production_exception()
+    {
+        $exception = $this->generate_dusk_exception();
+        $canSolve = app(RunningLaravelDuskInProductionProvider::class)->canSolve($exception);
+        [$first_solution, $second_solution] = app(RunningLaravelDuskInProductionProvider::class)->getSolutions($exception);
+
+        $this->assertTrue($canSolve);
+        $this->assertSame($first_solution->getSolutionTitle(), 'Laravel Dusk should not be run in production.');
+        $this->assertSame($first_solution->getSolutionDescription(), 'Install the dependencies with the `--no-dev` flag.');
+
+        $this->assertSame($second_solution->getSolutionTitle(), 'Laravel Dusk can be run in other environments.');
+        $this->assertSame($second_solution->getSolutionDescription(), 'Consider setting the `APP_ENV` to something other than `production` like `local` for example.');
+    }
+
+    private function generate_dusk_exception(): Exception
+    {
+        return new Exception('It is unsafe to run Dusk in production.');
+    }
+}


### PR DESCRIPTION
As requested in issue #71 

This PR provides two solutions for when Laravel Dusk is running in production.

1. install composer dependencies with the `--no-dev` flag
2. change the `APP_ENV` value