### PR TITLE
Adds margin on bottom of error card to give breathing room

### DIFF
--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <Summary />
-        <div class="layout-col mt-12">
+        <div class="layout-col mt-12 mb-4">
             <div class="tabs">
                 <Tabs v-model="tab" v-bind="{ customTabs }" />
                 <div class="tab-main">


### PR DESCRIPTION
This pull request adds margin on bottom to give breathing room, and also, to let us know that this end of page. 