### PR TITLE
TestCommand: Prevent undefined index exception

### DIFF
--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -50,7 +50,7 @@ class TestCommand extends Command
             $this->info("❌ The default logging channel `{$defaultLogChannel}` is not configured in the `logging` config file");
         }
 
-        if (! in_array('flare', $activeStack['channels'])) {
+        if (! isset($activeStack['channels']) || ! in_array('flare', $activeStack['channels'])) {
             $this->info("❌ The logging channel `{$defaultLogChannel}` does not contain the 'flare' channel");
         }
 


### PR DESCRIPTION
If `channels` is not set, an exception will occur: "Undefined index: channels".

With other logging methods such as stderr, for example, a "channels" array does not exist. This fix fixes this.