### PR TITLE
Remove arrow function to fix `this` keyword

### DIFF
--- a/resources/js/components/Stack/Snippet.vue
+++ b/resources/js/components/Stack/Snippet.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     watch: {
-        selectedFrame(value) {
+        selectedFrame() {
             this.highlightState = null;
         },
     },

--- a/resources/js/components/Stack/Snippet.vue
+++ b/resources/js/components/Stack/Snippet.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     watch: {
-        selectedFrame: function(value) {
+        selectedFrame(value) {
             this.highlightState = null;
         },
     },

--- a/resources/js/components/Stack/Snippet.vue
+++ b/resources/js/components/Stack/Snippet.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     watch: {
-        selectedFrame: value => {
+        selectedFrame: function(value) {
             this.highlightState = null;
         },
     },


### PR DESCRIPTION
See note about arrow functions here: https://vuejs.org/v2/guide/instance.html#Instance-Lifecycle-Hooks

Clicking any of the files listed in the stack trace result in a javascript console error:

```
TypeError: Cannot set property 'highlightState' of undefined
```

Click "server.php" (or any file listed in that column) and see the error in the console.

<img width="478" alt="Screen Shot 2019-09-18 at 4 29 50 PM" src="https://user-images.githubusercontent.com/271432/65183752-178f5480-da32-11e9-9abe-29e47e5a1d21.png">

Fixes #157 