### PR TITLE
Remove duplicate code, made by Fixes #138

### DIFF
--- a/src/ErrorPage/ErrorPageViewModel.php
+++ b/src/ErrorPage/ErrorPageViewModel.php
@@ -122,13 +122,9 @@ class ErrorPageViewModel implements Arrayable
 
     public function jsonEncode($data): string
     {
-        $jsonOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+        $jsonOptions = JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
 
-        if (version_compare(phpversion(), '7.2', '>=')) {
-            return json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR | $jsonOptions);
-        }
-
-        return json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR | $jsonOptions);
+        return json_encode($data, $jsonOptions);
     }
 
     public function getAssetContents(string $asset): string


### PR DESCRIPTION
After merging this commit into the master branch "[Ignore invalid characters in JSON encoding. Fixes #138](https://github.com/facade/ignition/commit/66c813c44230e95c5a0865b0dd78c9b51b2af095)" duplicate string and unnecessary php version check were added into the code:
[src/ErrorPage/ErrorPageViewModel.php:123](https://github.com/facade/ignition/blob/master/src/ErrorPage/ErrorPageViewModel.php#L123)

1. duplicate string:
return statement `return json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR | $jsonOptions);` is the same for both options, regardless to if statement condition.

2. unnecessary php version check
While working on issue #138 new json option `JSON_PARTIAL_OUTPUT_ON_ERROR` was added. But there is no need to check for php >= 7.2 because this option is available since php 5.5.0. Also, Ignition library has minumun version requirement of php 7.1.

I have checked that this change won't break existing unit tests.