### PR TITLE
Name routes

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -131,19 +131,22 @@ class IgnitionServiceProvider extends ServiceProvider
     protected function registerHousekeepingRoutes()
     {
         Route::group([
+            'as' => 'ignition.',
             'prefix' => config('ignition.housekeeping_endpoint_prefix', '_ignition'),
             'middleware' => [IgnitionEnabled::class],
         ], function () {
-            Route::get('health-check', HealthCheckController::class);
+            Route::get('health-check', HealthCheckController::class)->name('healthCheck');
 
             Route::post('execute-solution', ExecuteSolutionController::class)
-                ->middleware(IgnitionConfigValueEnabled::class.':enableRunnableSolutions');
+                ->middleware(IgnitionConfigValueEnabled::class.':enableRunnableSolutions')
+                ->name('executeSolution');
 
             Route::post('share-report', ShareReportController::class)
-                ->middleware(IgnitionConfigValueEnabled::class.':enableShareButton');
+                ->middleware(IgnitionConfigValueEnabled::class.':enableShareButton')
+                ->name('shareReport');
 
-            Route::get('scripts/{script}', ScriptController::class);
-            Route::get('styles/{style}', StyleController::class);
+            Route::get('scripts/{script}', ScriptController::class)->name('scripts');
+            Route::get('styles/{style}', StyleController::class)->name('styles');
         });
 
         return $this;


### PR DESCRIPTION
Hi,

It is good to have named routes, this is very useful when we need to whitelist/blacklist routes in packages like [Ziggy](https://github.com/tightenco/ziggy).