### PR TITLE
do not overflow the "card-details"

### DIFF
--- a/resources/js/components/Shared/OccurrenceDetails.vue
+++ b/resources/js/components/Shared/OccurrenceDetails.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="card-details-overflow scrollbar p-12 pt-10">
+    <div class="card-details scrollbar p-12 pt-10">
         <div class="text-2xl">
             <ExceptionClass :name="report.exception_class" />
             <ExceptionMessage :name="report.message" />


### PR DESCRIPTION
when using automated Browser testing with screenshots (like Dusk), we can't see the entire name of a long View file.

switching this class forces the text to wrap, which allows us to see the whole file in the screenshot.