### PR TITLE
Add exception to the bottom of the html

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -57,5 +57,8 @@
 <script>
     Ignition.start();
 </script>
+<!--
+<?=$throwableString?>
+-->
 </body>
 </html>


### PR DESCRIPTION
This PR is similar to https://github.com/facade/ignition/pull/206

I just ran into a test that failed because somewhere in a controller it fails a safety check and calls `abort(422)`. The test fails with the following message: "Response status code [422] is not a redirect status code.". Because this message isn't very useful, i decide to `dump()` the `TestResponse`. Doing that currently shows something like this:

![image](https://user-images.githubusercontent.com/7202674/71582604-3b6f3580-2b0b-11ea-91e6-19477377ff1f.png)

The exception message is at the top of the html, which means I have to scroll through a lot of inline javascript before seeing useful information about the error.

This PR adds the exception message to the bottom of the html, so that dumping the `TestResponse` immediately shows useful information:

![image](https://user-images.githubusercontent.com/7202674/71582659-740f0f00-2b0b-11ea-8195-d1929abf70dc.png)
