### PR TITLE
Change DumpRecorder dependency to use contract instead of Application.

### DIFF
--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -2,7 +2,7 @@
 
 namespace Facade\Ignition\DumpRecorder;
 
-use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -14,7 +14,7 @@ class DumpRecorder
 {
     protected $dumps = [];
 
-    /** @var \Illuminate\Foundation\Application */
+    /** @var \Illuminate\Contracts\Foundation\Application */
     protected $app;
 
     public function __construct(Application $app)


### PR DESCRIPTION
I've been trying to add Ignition to an OctoberCms application and so far the only thing that stops this is the hard-coded dependency to Illuminate\Foundation\Application instead of Illuminate\Contracts\Foundation\Application - because October changes the application instance with a custom one that implements the Contract.