### PR TITLE
Add a solution for unsupported cache::lock() driver

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -43,6 +43,7 @@ use Facade\Ignition\SolutionProviders\SolutionProviderRepository;
 use Facade\Ignition\SolutionProviders\TableNotFoundSolutionProvider;
 use Facade\Ignition\SolutionProviders\UndefinedVariableSolutionProvider;
 use Facade\Ignition\SolutionProviders\UnknownValidationSolutionProvider;
+use Facade\Ignition\SolutionProviders\UnsupportedCacheLockDriverProvider;
 use Facade\Ignition\SolutionProviders\ViewNotFoundSolutionProvider;
 use Facade\Ignition\Views\Engines\CompilerEngine;
 use Facade\Ignition\Views\Engines\PhpEngine;
@@ -364,6 +365,7 @@ class IgnitionServiceProvider extends ServiceProvider
             RunningLaravelDuskInProductionProvider::class,
             MissingColumnSolutionProvider::class,
             UnknownValidationSolutionProvider::class,
+            UnsupportedCacheLockDriverProvider::class,
         ];
     }
 

--- a/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
+++ b/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Facade\Ignition\SolutionProviders;
+
+use Exception;
+use Throwable;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+
+class UnsupportedCacheLockDriverProvider implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof Exception) {
+            return false;
+        }
+
+        return in_array($throwable->getMessage(), [
+            'Call to undefined method Illuminate\Cache\FileStore::lock()',
+            'Call to undefined method Illuminate\Cache\DatabaseStore::lock()',
+            'Call to undefined method Illuminate\Cache\ApcStore::lock()',
+        ]);
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            BaseSolution::create('Your current cache driver does not support atomic locks.')
+                ->setSolutionDescription('Consider switching to a cache driver to `redis`, `memcached`, or `dynamodb`.')
+                ->setDocumentationLinks(['Cache: Atomic Locks docs' => 'https://laravel.com/docs/7.x/cache#atomic-locks']),
+        ];
+    }
+}

--- a/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
+++ b/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
@@ -26,7 +26,7 @@ class UnsupportedCacheLockDriverProvider implements HasSolutionsForThrowable
     {
         return [
             BaseSolution::create('Your current cache driver does not support atomic locks.')
-                ->setSolutionDescription('Consider switching to a cache driver to `redis`, `memcached`, or `dynamodb`.')
+                ->setSolutionDescription('Consider switching your cache driver to `redis`, `memcached`, or `dynamodb`.')
                 ->setDocumentationLinks(['Cache: Atomic Locks docs' => 'https://laravel.com/docs/7.x/cache#atomic-locks']),
         ];
     }

--- a/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
+++ b/src/SolutionProviders/UnsupportedCacheLockDriverProvider.php
@@ -3,9 +3,9 @@
 namespace Facade\Ignition\SolutionProviders;
 
 use Exception;
-use Throwable;
 use Facade\IgnitionContracts\BaseSolution;
 use Facade\IgnitionContracts\HasSolutionsForThrowable;
+use Throwable;
 
 class UnsupportedCacheLockDriverProvider implements HasSolutionsForThrowable
 {

--- a/tests/Solutions/UnsupportedCacheLockDriverSolutionProviderTest.php
+++ b/tests/Solutions/UnsupportedCacheLockDriverSolutionProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Facade\Ignition\Tests\Solutions;
+
+use Exception;
+use Facade\Ignition\SolutionProviders\UnsupportedCacheLockDriverProvider;
+use Facade\Ignition\Tests\TestCase;
+use Facade\IgnitionContracts\Solution;
+
+class UnsupportedCacheLockDriverSolutionProviderTest extends TestCase
+{
+    public function cacheLockExceptionsProvider()
+    {
+        return [
+            ['Call to undefined method Illuminate\Cache\FileStore::lock()'],
+            ['Call to undefined method Illuminate\Cache\DatabaseStore::lock()'],
+            ['Call to undefined method Illuminate\Cache\ApcStore::lock()'],
+        ];
+    }
+
+    /**
+     * @dataProvider cacheLockExceptionsProvider
+     * @test
+     */
+    public function it_can_solve_unsupported_cache_lock_driver_exceptions($exceptionMessage)
+    {
+        $exception = new Exception($exceptionMessage);
+
+        $this->assertTrue(app(UnsupportedCacheLockDriverProvider::class)->canSolve($exception));
+
+        /** @var $solution Solution */
+        [$solution] = app(UnsupportedCacheLockDriverProvider::class)->getSolutions($exception);
+
+        $this->assertStringContainsString('current cache driver does not support atomic locks', $solution->getSolutionTitle());
+    }
+}


### PR DESCRIPTION
Not every cache driver supports using `Cache::lock()`. This PR adds a solution for the error you get if you try using atomic locks when using an unsupported driver.

[Cache::lock() documentation](https://laravel.com/docs/7.x/cache#atomic-locks)

---
2020-05-02 edit: The database driver will soon support atomic locks: https://github.com/laravel/framework/pull/32639

---

### Screenshot of the new solution
![image](https://user-images.githubusercontent.com/7202674/76087552-b135c880-5fb6-11ea-8b1a-597df3efbe60.png)
