### PR TITLE
Added "Undefined Property" solution

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -41,6 +41,7 @@ use Facade\Ignition\SolutionProviders\MissingPackageSolutionProvider;
 use Facade\Ignition\SolutionProviders\RunningLaravelDuskInProductionProvider;
 use Facade\Ignition\SolutionProviders\SolutionProviderRepository;
 use Facade\Ignition\SolutionProviders\TableNotFoundSolutionProvider;
+use Facade\Ignition\SolutionProviders\UndefinedPropertySolutionProvider;
 use Facade\Ignition\SolutionProviders\UndefinedVariableSolutionProvider;
 use Facade\Ignition\SolutionProviders\UnknownValidationSolutionProvider;
 use Facade\Ignition\SolutionProviders\ViewNotFoundSolutionProvider;
@@ -364,6 +365,7 @@ class IgnitionServiceProvider extends ServiceProvider
             RunningLaravelDuskInProductionProvider::class,
             MissingColumnSolutionProvider::class,
             UnknownValidationSolutionProvider::class,
+            UndefinedPropertySolutionProvider::class
         ];
     }
 

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -365,7 +365,7 @@ class IgnitionServiceProvider extends ServiceProvider
             RunningLaravelDuskInProductionProvider::class,
             MissingColumnSolutionProvider::class,
             UnknownValidationSolutionProvider::class,
-            UndefinedPropertySolutionProvider::class
+            UndefinedPropertySolutionProvider::class,
         ];
     }
 

--- a/src/SolutionProviders/UndefinedPropertySolutionProvider.php
+++ b/src/SolutionProviders/UndefinedPropertySolutionProvider.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Facade\Ignition\SolutionProviders;
+
+use ErrorException;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+use ReflectionProperty;
+use Throwable;
+
+class UndefinedPropertySolutionProvider implements HasSolutionsForThrowable
+{
+    protected const REGEX = '/([a-zA-Z\\\\]+)::\$([a-zA-Z]+)/m';
+    protected const MINIMUM_SIMILARITY = 80;
+
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof ErrorException) {
+            return false;
+        }
+
+        if (is_null($this->getClassAndPropertyFromExceptionMessage($throwable->getMessage()))) {
+            return false;
+        }
+
+        if (!$this->similarPropertyExists($throwable)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            BaseSolution::create('Unknown Property')
+            ->setSolutionDescription($this->getSolutionDescription($throwable)),
+        ];
+    }
+
+    public function getSolutionDescription(Throwable $throwable): string
+    {
+        if (! $this->canSolve($throwable) || !$this->similarPropertyExists($throwable)) {
+            return '';
+        }
+
+        extract($this->getClassAndPropertyFromExceptionMessage($throwable->getMessage()), EXTR_OVERWRITE);
+
+        $possibleProperty = $this->findPossibleProperty($class, $property);
+
+        return "Did you mean {$class}::\${$possibleProperty->name} ?";
+    }
+
+    protected function similarPropertyExists(Throwable $throwable)
+    {
+        extract($this->getClassAndPropertyFromExceptionMessage($throwable->getMessage()), EXTR_OVERWRITE);
+
+        $possibleProperty = $this->findPossibleProperty($class, $property);
+
+        return $possibleProperty !== null;
+    }
+
+    protected function getClassAndPropertyFromExceptionMessage(string $message): ?array
+    {
+        if (! preg_match(self::REGEX, $message, $matches)) {
+            return null;
+        }
+
+        return [
+            'class' => $matches[1],
+            'property' => $matches[2],
+        ];
+    }
+
+    protected function findPossibleProperty(string $class, string $invalidPropertyName)
+    {
+        return $this->getAvailableProperties($class)
+            ->sortByDesc(function (ReflectionProperty $property) use ($invalidPropertyName) {
+                similar_text($invalidPropertyName, $property->name, $percentage);
+
+                return $percentage;
+            })
+            ->filter(function (ReflectionProperty $property) use ($invalidPropertyName) {
+                similar_text($invalidPropertyName, $property->name, $percentage);
+
+                return $percentage >= self::MINIMUM_SIMILARITY;
+            })->first();
+    }
+
+    protected function getAvailableProperties($class): Collection
+    {
+        $class = new ReflectionClass($class);
+
+        return Collection::make($class->getProperties());
+    }
+}

--- a/src/SolutionProviders/UndefinedPropertySolutionProvider.php
+++ b/src/SolutionProviders/UndefinedPropertySolutionProvider.php
@@ -25,7 +25,7 @@ class UndefinedPropertySolutionProvider implements HasSolutionsForThrowable
             return false;
         }
 
-        if (!$this->similarPropertyExists($throwable)) {
+        if (! $this->similarPropertyExists($throwable)) {
             return false;
         }
 
@@ -42,7 +42,7 @@ class UndefinedPropertySolutionProvider implements HasSolutionsForThrowable
 
     public function getSolutionDescription(Throwable $throwable): string
     {
-        if (! $this->canSolve($throwable) || !$this->similarPropertyExists($throwable)) {
+        if (! $this->canSolve($throwable) || ! $this->similarPropertyExists($throwable)) {
             return '';
         }
 

--- a/tests/Solutions/UndefinedPropertySolutionProviderTest.php
+++ b/tests/Solutions/UndefinedPropertySolutionProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Facade\Ignition\SolutionProviders\UndefinedPropertySolutionProvider;
+use Facade\Ignition\Tests\TestCase;
+
+class UndefinedPropertySolutionProviderTest extends TestCase
+{
+    /** @test */
+    public function it_can_solve_an_undefined_property_exception_when_there_is_a_similar_property()
+    {
+        $canSolve = app(UndefinedPropertySolutionProvider::class)->canSolve($this->getUndefinedPropertyException());
+
+        $this->assertTrue($canSolve);
+    }
+
+    /** @test */
+    public function it_cannot_solve_an_undefined_property_exception_when_there_is_no_similar_property()
+    {
+        $canSolve = app(UndefinedPropertySolutionProvider::class)->canSolve($this->getUndefinedPropertyException('balance'));
+
+        $this->assertFalse($canSolve);
+    }
+
+    /** @test */
+    public function it_can_recommend_a_property_name_when_there_is_a_similar_property()
+    {
+        /** @var \Facade\IgnitionContracts\Solution $solution */
+        $solution = app(UndefinedPropertySolutionProvider::class)->getSolutions($this->getUndefinedPropertyException())[0];
+
+        $this->assertEquals('Did you mean Facade\Ignition\Tests\Support\Models\Car::$color ?', $solution->getSolutionDescription());
+    }
+
+    /** @test */
+    public function it_cannot_recommend_a_property_name_when_there_is_no_similar_property()
+    {
+        /** @var \Facade\IgnitionContracts\Solution $solution */
+        $solution = app(UndefinedPropertySolutionProvider::class)->getSolutions($this->getUndefinedPropertyException('balance'))[0];
+
+        $this->assertEquals('', $solution->getSolutionDescription());
+    }
+
+    protected function getUndefinedPropertyException(string $property = 'colro'): ErrorException
+    {
+        return new ErrorException("Undefined property: Facade\Ignition\Tests\Support\Models\Car::$$property ");
+    }
+}

--- a/tests/Support/Models/Car.php
+++ b/tests/Support/Models/Car.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Facade\Ignition\Tests\Support\Models;
+
+class Car
+{
+    public $brand;
+    public $color;
+
+    public function __construct($brand, $color)
+    {
+        $this->brand = $brand;
+        $this->color = $color;
+    }
+}


### PR DESCRIPTION
This solution provides the developer with a suggested object property name, if a similar one is found. This is useful in the case of a typo.  
You could compare this solution to [UndefinedVariableSolutionProvider](https://github.com/facade/ignition/blob/master/src/SolutionProviders/UndefinedVariableSolutionProvider.php), but for object properties.

## Example
Consider the following class:
```php
class Car 
{
	public $name;
}
```

Scenarios:
| Code  | Solution triggered? | Description
| ------------- | ------------- | ------------- |
| `$car->na`  | ❌ No  | - |
| `$car->nam`  | ✅ Yes  | Did you mean App\Car::$name ? |
| `$car->name`  | ❌ No  | - |
| `$car->namee`  | ✅ Yes  | Did you mean App\Car::$name ? |
| `$car->nameee`  | ✅ Yes  | Did you mean App\Car::$name ? |
| `$car->nameeee`  | ❌ No  | - |
| `$car->something`  | ❌ No  | - |

## Screenshot
![](https://i.imgur.com/DmWpSHp.png)

## Testing
```bash
./vendor/bin/phpunit --filter=UndefinedPropertySolutionProvider
```