### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "facade/flare-client-php": "^1.0",
         "facade/ignition-contracts": "^1.0",
         "filp/whoops": "^2.4",
-        "illuminate/support": "^7.0",
+        "illuminate/support": "^7.0|^8.0",
         "monolog/monolog": "^2.0",
         "scrivo/highlight.php": "^9.15",
         "symfony/console": "^5.0",


### PR DESCRIPTION
`laravel new myapp --dev` is currently broken because Ignition doesn't has the `^8.0` constraint yet.