### PR TITLE
Allow override of Dumper via SERVER variable

### DIFF
--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -82,7 +82,11 @@ class DumpRecorder
         return function ($value) {
             $data = (new VarCloner)->cloneVar($value);
 
-            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new BaseHtmlDumper;
+            if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
+                $dumper = 'html' === $_SERVER['VAR_DUMPER_FORMAT'] ? new BaseHtmlDumper : new CliDumper;
+            } else {
+                $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new BaseHtmlDumper;
+            }
             $dumper->dump($data);
         };
     }


### PR DESCRIPTION
Copy behavior from Symfony VarDumper.

PHP_SAPI cannot be changed but sometimes it can be helpful to enforce the dumper.