### PR TITLE
Handle exceptions in case the request doesn't have a user

### DIFF
--- a/src/Context/LaravelRequestContext.php
+++ b/src/Context/LaravelRequestContext.php
@@ -17,9 +17,13 @@ class LaravelRequestContext extends RequestContext
 
     public function getUser(): array
     {
-        $user = $this->request->user();
-
-        if (! $user) {
+        try {
+            $user = $this->request->user();
+    
+            if (! $user) {
+                return [];
+            }
+        } catch (\Throwable $e) {
             return [];
         }
 


### PR DESCRIPTION
In my multi-tenant app, the auth guard for some requests will only work once the DB connections are switched, so retrieving the user too early -- like Ignition does -- will result in an error.

With this change, the user probably won't be available in Ignition reports on tenant routes, but at least it won't throw an exception.