### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,16 +2,25 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
+/docs               export-ignore
+/resources/css      export-ignore
+/resources/js       export-ignore
+/tests              export-ignore
+/.babelrc           export-ignore
+/.editorconfig      export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
+/.prettierignore    export-ignore
+/.prettierrc        export-ignore
 /.scrutinizer.yml   export-ignore
-/tests              export-ignore
-/.editorconfig      export-ignore
-/docs               export-ignore
-/yarn.lock          export-ignore
-/package-lock.json  export-ignore
+/.styleci.yml       export-ignore
+/.travis.yml        export-ignore
 /CONTRIBUTING.md    export-ignore
-/resources/js       export-ignore
-/resources/css      export-ignore
+/package-lock.json  export-ignore
+/phpunit.xml.dist   export-ignore
+/postcss.config.js  export-ignore
+/tailwind.config.js export-ignore
+/tsconfig.json      export-ignore
+/webpack.config.js  export-ignore
+/yarn.lock          export-ignore


### PR DESCRIPTION
This commit is part of a campaign to reduce the amount of data transferred to save global bandwidth and reduce the amount of CO2. See https://github.com/Codeception/Codeception/pull/5527 for more info.

If I added to many files to the blacklist, please adjust the file yourself!