### PR TITLE
DocBlock support for BadeMethodCallSolution 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "illuminate/support": "^7.0|^8.0",
         "monolog/monolog": "^2.0",
         "scrivo/highlight.php": "^9.15",
+        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
         "symfony/console": "^5.0",
         "symfony/var-dumper": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/support": "^7.0|^8.0",
         "monolog/monolog": "^2.0",
         "scrivo/highlight.php": "^9.15",
-        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^4.0|^5.0",
         "symfony/console": "^5.0",
         "symfony/var-dumper": "^5.0"
     },

--- a/src/SolutionProviders/BadMethodCallSolutionProvider.php
+++ b/src/SolutionProviders/BadMethodCallSolutionProvider.php
@@ -83,7 +83,11 @@ class BadMethodCallSolutionProvider implements HasSolutionsForThrowable
 
     public function getAvailableMethodsFromClassDoc(ReflectionClass $class): Collection
     {
-        $doc = DocBlockFactory::createInstance()->create($class->getDocComment());
+        if (! $doc = $class->getDocComment()) {
+            return Collection::make([]);
+        }
+
+        $doc = DocBlockFactory::createInstance()->create($doc);
 
         $methods = [];
         foreach ($doc->getTagsByName('method') as $tag) {

--- a/src/SolutionProviders/BadMethodCallSolutionProvider.php
+++ b/src/SolutionProviders/BadMethodCallSolutionProvider.php
@@ -2,14 +2,14 @@
 
 namespace Facade\Ignition\SolutionProviders;
 
-use Throwable;
+use BadMethodCallException;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\HasSolutionsForThrowable;
+use Illuminate\Support\Collection;
+use phpDocumentor\Reflection\DocBlockFactory;
 use ReflectionClass;
 use ReflectionMethod;
-use BadMethodCallException;
-use Illuminate\Support\Collection;
-use Facade\IgnitionContracts\BaseSolution;
-use phpDocumentor\Reflection\DocBlockFactory;
-use Facade\IgnitionContracts\HasSolutionsForThrowable;
+use Throwable;
 
 class BadMethodCallSolutionProvider implements HasSolutionsForThrowable
 {
@@ -56,7 +56,7 @@ class BadMethodCallSolutionProvider implements HasSolutionsForThrowable
         }
 
         return [
-            'class' => $matches[1],
+            'class'  => $matches[1],
             'method' => $matches[2],
         ];
     }
@@ -66,6 +66,7 @@ class BadMethodCallSolutionProvider implements HasSolutionsForThrowable
         return $this->getAvailableMethods($class)
             ->sortByDesc(function ($method) use ($invalidMethodName) {
                 similar_text($invalidMethodName, $method, $percentage);
+
                 return $percentage;
             })->first();
     }

--- a/tests/ExceptionSolutionTest.php
+++ b/tests/ExceptionSolutionTest.php
@@ -2,6 +2,7 @@
 
 namespace Facade\Ignition\Tests;
 
+use BadMethodCallException;
 use Facade\Ignition\SolutionProviders\BadMethodCallSolutionProvider;
 use Facade\Ignition\SolutionProviders\MissingAppKeySolutionProvider;
 use Facade\Ignition\SolutionProviders\SolutionProviderRepository;
@@ -123,5 +124,29 @@ class ExceptionSolutionTest extends TestCase
         $solution = new MissingAppKeySolutionProvider();
 
         $this->assertSame('Generate your application encryption key using `php artisan key:generate`.', $solution->getSolutions($exception)[0]->getSolutionActionDescription());
+    }
+
+    /** @test */
+    public function it_can_propose_doc_block_solutions_for_bad_method_call_exceptions()
+    {
+        try {
+            $user = new ClassWithDocBlock();
+            $user->teest();
+        } catch (\Exception $exception) {
+            $solution = new BadMethodCallSolutionProvider();
+
+            $this->assertSame('Did you mean Facade\Ignition\Tests\ClassWithDocBlock::test() ?', $solution->getSolutions($exception)[0]->getSolutionDescription());
+        }
+    }
+}
+
+/**
+ * @method void test()
+ */
+class ClassWithDocBlock
+{
+    public function __call($method, $parameters = [])
+    {
+        throw new BadMethodCallException(static::class.'::'.$method);
     }
 }


### PR DESCRIPTION
This pull request adds methods that are defined in a classes docblock to the `BadMethodCallSolutionProvider`.

```php
/**
 * @method string myMethod()
 */
class MyClass
{

}
```

Helpfull to give better solutions for facades.