### PR TITLE
Make DumpHandler instance manually in DumpRecorder::register()

### DIFF
--- a/src/DumpRecorder/DumpHandler.php
+++ b/src/DumpRecorder/DumpHandler.php
@@ -6,7 +6,7 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class DumpHandler
 {
-    /** @var \Facade\Flare\DumpRecorder\DumpRecorder */
+    /** @var \Facade\Ignition\DumpRecorder\DumpRecorder */
     protected $dumpRecorder;
 
     public function __construct(DumpRecorder $dumpRecorder)

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -39,7 +39,7 @@ class DumpRecorder
         }
 
         $multiDumpHandler->addHandler(function ($var) {
-            $this->app->make(DumpHandler::class)->dump($var);
+            (new DumpHandler($this))->dump($var);
         });
 
         return $this;


### PR DESCRIPTION
As described in #275, `$this->app->make()` call on `DumpHandler` overrides singleton instance of `Application` class and this breaks any calls to `Application::getNamespace()` method after `dump`ing something in tests.