### PR TITLE
fix: properly bind singleton

### DIFF
--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -26,7 +26,9 @@ class DumpRecorder
     {
         $multiDumpHandler = new MultiDumpHandler();
 
-        $this->app->singleton(MultiDumpHandler::class, $multiDumpHandler);
+        $this->app->singleton(MultiDumpHandler::class, function () use ($multiDumpHandler) {
+            return $multiDumpHandler;
+        });
 
         $previousHandler = VarDumper::setHandler(function ($var) use ($multiDumpHandler) {
             $multiDumpHandler->dump($var);


### PR DESCRIPTION
fixes #290 

👋 You may want to consider bringing in psalm to help ya out!

The typehint for `Container::singleton` is `@param  \Closure|string|null  $concrete` https://github.com/laravel/framework/blob/7.x/src/Illuminate/Container/Container.php#L352
