### PR TITLE
Catch exception in detectLineNumber for not existing blade files.

### DIFF
--- a/src/Views/Compilers/BladeSourceMapCompiler.php
+++ b/src/Views/Compilers/BladeSourceMapCompiler.php
@@ -2,13 +2,19 @@
 
 namespace Facade\Ignition\Views\Compilers;
 
+use ErrorException;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeSourceMapCompiler extends BladeCompiler
 {
     public function detectLineNumber(string $filename, int $exceptionLineNumber): int
     {
-        $map = $this->compileString(file_get_contents($filename));
+        try {
+            $map = $this->compileString(file_get_contents($filename));
+        } catch (ErrorException $e) {
+            return 1;
+        }
+        
         $map = explode("\n", $map);
 
         $line = $map[$exceptionLineNumber - 1] ?? $exceptionLineNumber;


### PR DESCRIPTION
I stumbled over this while testing mocked blade views. In that case I just want to test the compiled view without having an existing template file. Whenever there is an exception in the view, `detectLineNumber` in `Facade\Ignition\Views\Compilers\BladeSourceMapCompiler` fails, since it cannot open the view path. However I would like to see the exceptions in my views anyway. I suggest to return line number `1` in that case.

This is the exception I get when I render mocked blade templates:

```shell
Caused by
ErrorException: file_get_contents(/Users/helen/git/cbl/loewe/vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php(34) : eval()'d code): failed to open stream: No such file or directory

/Users/helen/git/dev-ui-kit/packages/fjord-ui-kit/vendor/facade/ignition/src/Views/Compilers/BladeSourceMapCompiler.php:13
/Users/helen/git/dev-ui-kit/packages/fjord-ui-kit/vendor/facade/ignition/src/Views/Engines/CompilerEngine.php:98
...
```

With catching the `ErrorException`:

```shell
Caused by
Mockery\Exception\BadMethodCallException: Received Mockery_2_Fjord_Crud_Models_Media::offsetExists(), but no expectations were specified

/Users/helen/git/dev-ui-kit/packages/fjord-ui-kit/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1701
/Users/helen/git/dev-ui-kit/packages/fjord-ui-kit/vendor/laravel/framework/src/Illuminate/View/Engines/PhpEngine.php:41
...
```