### PR TITLE
Fix missing constructor argument for PhpEngine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "mockery/mockery": "^1.3",
-        "orchestra/testbench": "5.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "psalm/plugin-laravel": "^1.2"
     },
     "suggest": {

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -125,7 +125,7 @@ class IgnitionServiceProvider extends ServiceProvider
         }
 
         $this->app->make('view.engine.resolver')->register('php', function () {
-            return new PhpEngine();
+            return new PhpEngine($this->app['files']);
         });
 
         $this->app->make('view.engine.resolver')->register('blade', function () {


### PR DESCRIPTION
Added the `\Illuminate\Filesystem\Filesystem` dependency when creating a `Facade\Ignition\Views\Engines\PhpEngine` instance for compatibility with Laravel 8.x and updated `orchestra/testbench` to allow version compatible with laravel 8.x

fixes #306 