### PR TITLE
Support PHP 8 in Ignition v1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure()
+              if: failure() && !! secrets.SLACK_WEBHOOK
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure()
+              if: failure() && !! secrets.SLACK_WEBHOOK
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: ${{ failure() && !! secrets.SLACK_WEBHOOK }}
+              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: ${{ failure() && !! secrets.SLACK_WEBHOOK }}
+              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2]
+                php: [8.0, 7.4, 7.3, 7.2]
                 laravel: [6.*, 5.8.*, 5.7.*, 5.6.*, 5.5.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
@@ -27,6 +27,14 @@ jobs:
                     - laravel: 5.5.*
                       testbench: 3.5.*
                 exclude:
+                    - laravel: 5.8.*
+                      php: 8.0
+                    - laravel: 5.7.*
+                      php: 8.0
+                    - laravel: 5.6.*
+                      php: 8.0
+                    - laravel: 5.5.*
+                      php: 8.0
                     - laravel: 5.7.*
                       php: 7.4
                     - laravel: 5.6.*
@@ -79,7 +87,7 @@ jobs:
 
             -   name: Execute tests
                 run: yarn run jest
-                
+
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
               if: failure()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,10 +47,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v1
+              uses: actions/checkout@v2
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v1
+              uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,7 +53,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, fileinfo
                   coverage: none
 
             - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,7 +53,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
                   coverage: none
 
             - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   push:
+  pull_request:
   schedule:
       - cron: '0 0 * * *'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,7 +53,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                  extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                   coverage: none
 
             - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure()
+              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure()
+              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure() && !! secrets.SLACK_WEBHOOK
+              if: failure() && !! ${{ secrets.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure() && !! secrets.SLACK_WEBHOOK
+              if: failure() && !! ${{ secrets.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure() && !! ${{ secrets.SLACK_WEBHOOK }}
+              if: ${{ failure() && !! secrets.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: failure() && !! ${{ secrets.SLACK_WEBHOOK }}
+              if: ${{ failure() && !! secrets.SLACK_WEBHOOK }}
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
+              if: failure()
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Send Slack notification
               uses: 8398a7/action-slack@v2
-              if: ${{ failure() && !! env.SLACK_WEBHOOK }}
+              if: failure()
               with:
                   status: ${{ job.status }}
                   author_name: ${{ github.actor }}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "symfony/var-dumper": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.14",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^3.5 || ^3.6 || ^3.7 || ^3.8 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/facade/ignition",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "facade/flare-client-php": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/var-dumper": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.2",
+        "mockery/mockery": "~1.3.3|^1.4.2",
         "orchestra/testbench": "^3.5 || ^3.6 || ^3.7 || ^3.8 || ^4.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/SolutionProviders/MergeConflictSolutionProvider.php
+++ b/src/SolutionProviders/MergeConflictSolutionProvider.php
@@ -17,7 +17,7 @@ class MergeConflictSolutionProvider implements HasSolutionsForThrowable
             return false;
         }
 
-        if (! Str::startsWith($throwable->getMessage(), 'syntax error, unexpected \'<<\'')) {
+        if (! $this->hasMergeConflictExceptionMessage($throwable)) {
             return false;
         }
 
@@ -57,5 +57,20 @@ class MergeConflictSolutionProvider implements HasSolutionsForThrowable
         }
 
         return $branch;
+    }
+
+    protected function hasMergeConflictExceptionMessage(Throwable $throwable): bool
+    {
+        // For PHP 7.x and below
+        if (Str::startsWith($throwable->getMessage(), 'syntax error, unexpected \'<<\'')) {
+            return true;
+        }
+
+        // For PHP 8+
+        if (Str::startsWith($throwable->getMessage(), 'syntax error, unexpected token "<<"')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Solutions/MergeConflictSolutionProviderTest.php
+++ b/tests/Solutions/MergeConflictSolutionProviderTest.php
@@ -25,6 +25,7 @@ class MergeConflictSolutionProviderTest extends TestCase
         } catch (ParseError $error) {
             $exception = $error;
         }
+
         $canSolve = app(MergeConflictSolutionProvider::class)->canSolve($exception);
 
         $this->assertTrue($canSolve);


### PR DESCRIPTION
We'll need v1 to support PHP 8 to allow the Laravel v6 skeleton to install.