### PR TITLE
Fix double `$` on PHP 8

### DIFF
--- a/src/SolutionProviders/UndefinedVariableSolutionProvider.php
+++ b/src/SolutionProviders/UndefinedVariableSolutionProvider.php
@@ -79,6 +79,7 @@ class UndefinedVariableSolutionProvider implements HasSolutionsForThrowable
 
         if (count($matches) === 3) {
             [, $variableName, $viewFile] = $matches;
+            $variableName = ltrim($variableName, '$');
 
             return compact('variableName', 'viewFile');
         }


### PR DESCRIPTION
On PHP 8.0 RC5 the variable name is shown with double $. This makes the button "Make variable optional" not working, because it searches for '{{ $$myVar }}' instead '{{ $myVar }}'.

This Pull request Strip's `$` sign from the beginning of the matched variable name. 

**Environment:**
OS: macOS BigSur 11.0.1
Laravel Valet Version: 2.13.2
PHP: 8.0 RC5

Tests are green on both PHP 7.4 and 8.0.

![Bildschirmfoto 2020-11-25 um 23 20 53](https://user-images.githubusercontent.com/1866678/100279845-55620400-2f78-11eb-9040-bfe4312d48d1.png)
