### PR TITLE
Use Livewire compatible compiler engine when using Livewire 

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -131,6 +131,10 @@ class IgnitionServiceProvider extends ServiceProvider
         });
 
         $this->app->make('view.engine.resolver')->register('blade', function () {
+            if (class_exists(\Livewire\LivewireServiceProvider::class)) {
+                return new \Livewire\CompilerEngineForIgnition($this->app['blade.compiler']);
+            }
+
             return new CompilerEngine($this->app['blade.compiler']);
         });
 

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -131,7 +131,7 @@ class IgnitionServiceProvider extends ServiceProvider
         });
 
         $this->app->make('view.engine.resolver')->register('blade', function () {
-            if (class_exists(\Livewire\LivewireServiceProvider::class)) {
+            if (class_exists(\Livewire\CompilerEngineForIgnition::class)) {
                 return new \Livewire\CompilerEngineForIgnition($this->app['blade.compiler']);
             }
 


### PR DESCRIPTION
Applications using both Ignition and Livewire can be unruly at times due to Laravel expecting only a single view compiler engine to be bound in the container. 

In https://github.com/livewire/livewire/pull/2160 I have explained the issues in more detail. Due to Laravel expecting a single binding, it seems that this needs to be handled from both sides.

I am marking this as a draft until the final API is decided upon in the Livewire repo. Thank you! 