### PR TITLE
facade/ignition#344: Fix wrong config usage

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -340,7 +340,7 @@ class IgnitionServiceProvider extends ServiceProvider
             return new QueryRecorder(
                 $app,
                 $app->get('config')->get('flare.reporting.report_query_bindings'),
-                $app->get('config')->get('flare.reporting.maximum_number_of_collected_logs')
+                $app->get('config')->get('flare.reporting.maximum_number_of_collected_queries')
             );
         });
 


### PR DESCRIPTION
This fixes a copy paste bug that got overseen. A config value has not been used at all, instead a different config value has been used in the wrong place.

Closes #302 

Closes #301 