### PR TITLE
[WIP] Register ExceptionRenderer to be used in Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "ext-mbstring": "*",
         "facade/flare-client-php": "^1.6",
         "facade/ignition-contracts": "^1.0.2",
-        "filp/whoops": "^2.4",
         "illuminate/support": "^7.0|^8.0",
         "monolog/monolog": "^2.0",
         "symfony/console": "^5.0",

--- a/src/ErrorPage/IgnitionExceptionHandler.php
+++ b/src/ErrorPage/IgnitionExceptionHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Facade\Ignition\ErrorPage;
+
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
+
+class IgnitionExceptionHandler implements ExceptionRenderer
+{
+    /** @var \Facade\Ignition\ErrorPage\ErrorPageHandler */
+    protected $errorPageHandler;
+
+    public function __construct(ErrorPageHandler $errorPageHandler)
+    {
+        $this->errorPageHandler = $errorPageHandler;
+    }
+
+    public function render($throwable)
+    {
+        ob_start();
+
+        $this->errorPageHandler->handle($throwable);
+
+        return ob_get_clean();
+    }
+}

--- a/src/ErrorPage/IgnitionExceptionRenderer.php
+++ b/src/ErrorPage/IgnitionExceptionRenderer.php
@@ -4,7 +4,7 @@ namespace Facade\Ignition\ErrorPage;
 
 use Illuminate\Contracts\Foundation\ExceptionRenderer;
 
-class IgnitionExceptionHandler implements ExceptionRenderer
+class IgnitionExceptionRenderer implements ExceptionRenderer
 {
     /** @var \Facade\Ignition\ErrorPage\ErrorPageHandler */
     protected $errorPageHandler;

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -11,6 +11,7 @@ use Facade\Ignition\Commands\SolutionProviderMakeCommand;
 use Facade\Ignition\Commands\TestCommand;
 use Facade\Ignition\Context\LaravelContextDetector;
 use Facade\Ignition\DumpRecorder\DumpRecorder;
+use Facade\Ignition\ErrorPage\IgnitionExceptionRenderer;
 use Facade\Ignition\ErrorPage\IgnitionWhoopsHandler;
 use Facade\Ignition\ErrorPage\Renderer;
 use Facade\Ignition\Exceptions\InvalidConfig;
@@ -213,10 +214,10 @@ class IgnitionServiceProvider extends ServiceProvider
         }
 
         if (class_exists(\Illuminate\Contracts\Foundation\ExceptionRenderer::class)) {
-        $this->app->bind(\Illuminate\Contracts\Foundation\ExceptionRenderer::class, function (Application $app) {
-            return $app->make(IgnitionWhoopsHandler::class);
-        });
-    }
+            $this->app->bind(\Illuminate\Contracts\Foundation\ExceptionRenderer::class, function (Application $app) {
+                return $app->make(IgnitionExceptionRenderer::class);
+            });
+        }
 
         return $this;
     }

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -207,13 +207,13 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function registerExceptionRenderer()
     {
-        if (class_exists(\Whoops\Handler\HandlerInterface::class)) {
+        if (interface_exists(\Whoops\Handler\HandlerInterface::class)) {
             $this->app->bind(\Whoops\Handler\HandlerInterface::class, function (Application $app) {
                 return $app->make(IgnitionWhoopsHandler::class);
             });
         }
 
-        if (class_exists(\Illuminate\Contracts\Foundation\ExceptionRenderer::class)) {
+        if (interface_exists(\Illuminate\Contracts\Foundation\ExceptionRenderer::class)) {
             $this->app->bind(\Illuminate\Contracts\Foundation\ExceptionRenderer::class, function (Application $app) {
                 return $app->make(IgnitionExceptionRenderer::class);
             });


### PR DESCRIPTION
This PR registers Ignition as an `ExceptionRenderer` in Laravel 9 (if/when it gets merged). It keeps backwards compatibility with previous Laravel versions using the old `WhoopsHandler` interface.