### PR TITLE
Use \Closure instead of callable - fix #401

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -492,20 +492,30 @@ class IgnitionServiceProvider extends ServiceProvider
     {
         // Reset before executing a queue job to make sure the job's log/query/dump recorders are empty.
         // When using a sync queue this also reports the queued reports from previous exceptions.
-        $queue->before([$this, 'resetFlare']);
+        $queue->before(function () {
+             $this->resetFlare();
+        });
 
         // Send queued reports (and reset) after executing a queue job.
-        $queue->after([$this, 'resetFlare']);
+        $queue->after(function () {
+             $this->resetFlare();
+        });
 
         // Note: the $queue->looping() event can't be used because it's not triggered on Vapor
     }
 
     protected function setupOctane()
     {
-        $this->app['events']->listen(RequestReceived::class, [$this, 'resetFlare']);
+        $this->app['events']->listen(RequestReceived::class, function () {
+             $this->resetFlare();
+        });
 
-        $this->app['events']->listen(TaskReceived::class, [$this, 'resetFlare']);
+        $this->app['events']->listen(TaskReceived::class, function () {
+             $this->resetFlare();
+        });
 
-        $this->app['events']->listen(TickReceived::class, [$this, 'resetFlare']);
+        $this->app['events']->listen(TickReceived::class, function () {
+             $this->resetFlare();
+        });
     }
 }


### PR DESCRIPTION
PR #398 fixed and issue with Laravel Vapor, but changed `\Closure` usage to callable.

Problem is Laravel Event Dispatcher treats `\Closure`...

https://github.com/laravel/framework/blob/c7824d4e163947331d2676dc35213126499736a1/src/Illuminate/Events/Dispatcher.php#L79-L81

... differently than callables ...

https://github.com/laravel/framework/blob/c7824d4e163947331d2676dc35213126499736a1/src/Illuminate/Events/Dispatcher.php#L87-L93

... as such `$this` refers to different objects when using these two different syntax.

**both snippets are from the same `Dispatcher@listen` method**

which causes issues with queued jobs as reported in #401 

For example after updating to 2.11.1 I got these errors on production:

![image](https://user-images.githubusercontent.com/5470108/126332880-56e786f4-a49f-4548-9ea0-05a48970d926.png)

I reverted back to 2.11.0 to avoid issues.

This PR keeps the Vapor related changes from PR #398 (not using the `looping` listener) but reverts to call `$this->resetFlare();` from within a `\Closure` (anonymous function) so the `$this` context is preserved.

I didn't added any automated tests as this was an emergency or hot fix to #401 but I tested manually symlinking the fixed repo to my local app.

(closes #401)