### PR TITLE
Resolve view engine when needed

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -426,6 +426,10 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function hasCustomViewEnginesRegistered()
     {
+        if (! $this->app->resolved('view.engine.resolver')) {
+            return false;
+        }
+        
         $resolver = $this->app->make('view.engine.resolver');
 
         if (! $resolver->resolve('php') instanceof LaravelPhpEngine) {


### PR DESCRIPTION
in my laravel app (telegram) i dont have any View system so, when i disable the `Illuminate\View\ViewServiceProvider::class` in app.php i cant use Cache system and i'll get: `Target class [view.engine.resolver] does not exist.` error, so: