### PR TITLE
Fix Circular references in Route parameters #352

### DIFF
--- a/src/Context/LaravelRequestContext.php
+++ b/src/Context/LaravelRequestContext.php
@@ -3,6 +3,7 @@
 namespace Facade\Ignition\Context;
 
 use Facade\FlareClient\Context\RequestContext;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Throwable;
 
@@ -70,7 +71,9 @@ class LaravelRequestContext extends RequestContext
     protected function getRouteParameters(): array
     {
         try {
-            return collect(optional($this->request->route())->parameters ?? [])->toArray();
+            return collect(optional($this->request->route())->parameters ?? [])
+                ->map(fn ($parameter) => $parameter instanceof Model ? $parameter->withoutRelations() : $parameter)
+                ->toArray();
         } catch (Throwable $e) {
             return [];
         }


### PR DESCRIPTION
This fixes #352, by unloading Model relations before casting Models to array. 

I'm not familiar enough with testing Route Model binding to add a test for this unfortunately, hope that's ok.