### PR TITLE
Use npm ci instead of install

### DIFF
--- a/src/SolutionProviders/MissingMixManifestSolutionProvider.php
+++ b/src/SolutionProviders/MissingMixManifestSolutionProvider.php
@@ -19,7 +19,7 @@ class MissingMixManifestSolutionProvider implements HasSolutionsForThrowable
     {
         return [
             BaseSolution::create('Missing Mix Manifest File')
-                ->setSolutionDescription('Did you forget to run `npm install && npm run dev`?'),
+                ->setSolutionDescription('Did you forget to run `npm ci && npm run dev`?'),
         ];
     }
 }


### PR DESCRIPTION
I would suggest to use `npm ci` instead of `npm install`. 

`npm ci` does only install dependencies as locked in the package.lock file. This does mean, that `npm ci` can be compared with `composer install` in PHP. 

**Why not to use `install`**
Install might update dependencies and might create a new package.lock. 

**Downsides of `install`**
In case someone does not have a package.lock file, npm will throw an error message saying that you need to run `npm install`. 

This may sound like a downside, but personally I think this is fine as the same is required if using `composer install` in PHP.