### PR TITLE
Enable PHP 8.1 builds

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
+                composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update -W --prefer-stable
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,15 +36,10 @@ jobs:
                   coverage: none
                   tools: composer:v2
 
-            - name: Install PHP 7 dependencies
+            - name: Install dependencies
               run: |
                 composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
-              if: "matrix.php < 8"
-
-            - name: Install PHP 8 dependencies
-              run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
-              if: "matrix.php >= 8"
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,13 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 8.0, 8.1]
+                php: ['7.4', '8.0', '8.1']
                 laravel: [^7.0, ^8.0]
                 dependency-version: [prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:
                     - laravel: ^7.0
-                      php: 8.1
+                      php: '8.1'
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -40,7 +40,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,13 @@ jobs:
 
         strategy:
             matrix:
-                php: ['7.4', '8.0', '8.1']
-                laravel: [^7.0, ^8.0]
+                php: [7.4, 8.0, 8.1]
+                laravel: [7.*, 8.*]
                 dependency-version: [prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:
-                    - laravel: ^7.0
-                      php: '8.1'
+                    - laravel: 7.*
+                      php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -39,9 +39,7 @@ jobs:
               if: matrix.php > 8
 
             - name: Install dependencies
-              run: |
-                composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update -W --prefer-stable
-                composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
+              run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,11 +16,9 @@ jobs:
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-stable]
                 os: [ubuntu-latest, windows-latest]
-                include:
+                exclude:
                     - laravel: 7.*
-                      testbench: 5.*
-                    - laravel: 8.*
-                      testbench: 6.*
+                      php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -38,7 +36,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,11 @@ jobs:
         strategy:
             matrix:
                 php: [7.4, 8.0, 8.1]
-                laravel: [7.*, 8.*]
+                laravel: [^7.0, ^8.0]
                 dependency-version: [prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:
-                    - laravel: 7.*
+                    - laravel: ^7.0
                       php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
@@ -30,7 +30,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                   coverage: none
                   tools: composer:v2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,11 +40,11 @@ jobs:
               run: |
                 composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
-              if: "matrix.php < 8.1"
+              if: "matrix.php < 8"
 
-            - name: Install PHP 8.1 dependencies
+            - name: Install PHP 8 dependencies
               run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
-              if: "matrix.php >= 8.1"
+              if: "matrix.php >= 8"
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 8.0]
+                php: [7.4, 8.0, 8.1]
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-stable]
                 os: [ubuntu-latest, windows-latest]
@@ -40,11 +40,11 @@ jobs:
               run: |
                 composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                 composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
-              if: "matrix.php < 8"
+              if: "matrix.php < 8.1"
 
-            - name: Install PHP 8 dependencies
+            - name: Install PHP 8.1 dependencies
               run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
-              if: "matrix.php >= 8"
+              if: "matrix.php >= 8.1"
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,10 @@ jobs:
                   coverage: none
                   tools: composer:v2
 
+            - name: Mimic PHP 8.0
+              run: composer config platform.php 8.0.999
+              if: matrix.php > 8
+
             - name: Install dependencies
               run: |
                 composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,12 +34,10 @@ jobs:
                   coverage: none
                   tools: composer:v2
 
-            - name: Mimic PHP 8.0
-              run: composer config platform.php 8.0.999
-              if: matrix.php > 8
-
             - name: Install dependencies
-              run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+              run: |
+                composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-mbstring": "*",
         "facade/flare-client-php": "^1.9.1",
         "facade/ignition-contracts": "^1.0.2",
-        "illuminate/support": "^7.0|^8.53",
+        "illuminate/support": "^7.0|^8.0",
         "monolog/monolog": "^2.0",
         "symfony/console": "^5.0",
         "symfony/var-dumper": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-mbstring": "*",
         "facade/flare-client-php": "^1.9.1",
         "facade/ignition-contracts": "^1.0.2",
-        "illuminate/support": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.53",
         "monolog/monolog": "^2.0",
         "symfony/console": "^5.0",
         "symfony/var-dumper": "^5.0"


### PR DESCRIPTION
Enables PHP 8.1 builds. No necessary changes it seems based from the current test suite. 

I've removed the testbench toggling in the CI setup as the composer can resolve the correct one. I've also removed the separate PHP 8 >= vs PHP 8 < composer dependency requirements as `--ignore-platform-req=php` is no longer required at this time in PHP 8.1's development cycle.