### PR TITLE
Fix E_NOTICE when requesting invalid script

### DIFF
--- a/src/Http/Controllers/ScriptController.php
+++ b/src/Http/Controllers/ScriptController.php
@@ -9,6 +9,9 @@ class ScriptController
 {
     public function __invoke(Request $request)
     {
+        if (!isset(Ignition::scripts()[$request->script])) {
+            abort(404, 'Script not found');
+        }
         return response(
             file_get_contents(
                 Ignition::scripts()[$request->script]


### PR DESCRIPTION
It is possible to trigger an exception by requesting an invalid script path.

The following URL path leads to XSS on the exception page,
showing two nice popups:

    http://myapp/_ignition/scripts/--><svg onload=alert(1337)>

The exception is:

    ErrorException
    Undefined index: --><svg onload=alert(1337)>

    Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
    vendor/facade/ignition/src/Http/Controllers/ScriptController.php:14

This happens with facade/ignition 1.18.0 (the last with laravel 6 support)
and should be fixed there.
The error probably also occurs in all later versions.


![2022-02-23_1](https://user-images.githubusercontent.com/59036/155356120-7246905b-d634-4405-ac18-f7ee8d032b1e.png)