### PR TITLE
Feat flush view data

### DIFF
--- a/src/Views/Concerns/CollectsViewExceptions.php
+++ b/src/Views/Concerns/CollectsViewExceptions.php
@@ -21,6 +21,9 @@ trait CollectsViewExceptions
     
     public function flushViewData(): void
     {
+        // If we need to render multiple views at the same time, 
+        // $lastCompiledData will hold all the view data, which can lead to excessive memory usage.
+        // We can flush the view data so that we can prevent memory transitions and also improve retrieval efficiency.
         $this->lastCompiledData = [];
     }
 


### PR DESCRIPTION
The view data keeps appending causing memory to increase.

For example.

There is a timed task to send emails, I send 100 emails with different data, the view data length will be 100, the data volume is large but the memory is relatively small, it can easily lead to killed.

Add a method to clean up view data, users can clean up unnecessary data by themselves to protect memory.

```php
for ($index = 0; $index < 100; $index++) {
    /* @var Factory $viewFactor */
    $viewFactor = Mail::getViewFactory();

    $view = $viewFactor->make('email.view', [
        // big data......
    ]);

    // get html
    $data = $view->render();

    /* @var CompilerEngine $viewEngine */
    $viewEngine = $view->getEngine();
    $viewEngine->flushViewData();

    // send mail via raw data
    // ......
}
```