### PR TITLE
notice if dots have been used in the view name

### DIFF
--- a/src/SolutionProviders/ViewNotFoundSolutionProvider.php
+++ b/src/SolutionProviders/ViewNotFoundSolutionProvider.php
@@ -34,6 +34,13 @@ class ViewNotFoundSolutionProvider implements HasSolutionsForThrowable
 
         $suggestedView = $this->findRelatedView($missingView);
 
+        if ($suggestedView == $missingView) {
+            return [
+                BaseSolution::create("{$missingView} was not found.")
+                    ->setSolutionDescription('View names should not contain the . character!'),
+            ];
+        }
+
         if ($suggestedView) {
             return [
                 BaseSolution::create("{$missingView} was not found.")

--- a/tests/Solutions/ViewNotFoundSolutionProviderTest.php
+++ b/tests/Solutions/ViewNotFoundSolutionProviderTest.php
@@ -35,6 +35,15 @@ class ViewNotFoundSolutionProviderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_notice_if_the_view_name_contains_dots()
+    {
+        /** @var \Facade\IgnitionContracts\Solution $solution */
+        $solution = app(ViewNotFoundSolutionProvider::class)->getSolutions($this->getViewNotFoundException('foo.bar'))[0];
+
+        $this->assertTrue(Str::contains($solution->getSolutionDescription(), 'the . character'));
+    }
+
+    /** @test */
     public function it_wont_recommend_another_controller_class_if_the_names_are_too_different()
     {
         $unknownView = 'a-view-that-doesnt-exist-and-is-not-a-typo';

--- a/tests/stubs/views/foo.bar.blade.php
+++ b/tests/stubs/views/foo.bar.blade.php
@@ -1,0 +1,1 @@
+<h1>This is a blade view</h1>


### PR DESCRIPTION
> View directory names should not contain the . character.
https://laravel.com/docs/9.x/views#nested-view-directories

Today I got this message because I had used a name like `foo.bar.blade.php` for my view file:
>View [foo.bar] not found.
Did you mean foo.bar?  

It's funny and confusing, not clear and helping!

This happens because Laravel replaces the dots with slashes so it thinks that we want this file:
```
views
    foo
        bar.{extension}
```

The solution description is pretty deceptive, so I have fixed that by adding a condition that you can see it in my commit. This is the new solution description when anyone makes that mistake:
> View names should not contain the . character.