### PR TITLE
Support illuminate/support v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-mbstring": "*",
         "facade/flare-client-php": "^1.9.1",
         "facade/ignition-contracts": "^1.0.2",
-        "illuminate/support": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0|^9.0",
         "monolog/monolog": "^2.0",
         "symfony/console": "^5.0",
         "symfony/var-dumper": "^5.0",


### PR DESCRIPTION
This is required to be able to run Laravel Dusk 7 on a Laravel 8 project