### PR TITLE
Replace ${var} with {$var}

### DIFF
--- a/src/SolutionProviders/MergeConflictSolutionProvider.php
+++ b/src/SolutionProviders/MergeConflictSolutionProvider.php
@@ -49,7 +49,7 @@ class MergeConflictSolutionProvider implements HasSolutionsForThrowable
 
     protected function getCurrentBranch(string $directory): string
     {
-        $branch = "'".trim(shell_exec("cd ${directory}; git branch | grep \\* | cut -d ' ' -f2"))."'";
+        $branch = "'".trim(shell_exec("cd {$directory}; git branch | grep \\* | cut -d ' ' -f2"))."'";
 
         if ($branch === "''") {
             $branch = 'current branch';


### PR DESCRIPTION
```
Uncaught Whoops\Exception\ErrorException: Using ${var} in strings is deprecated, use {$var} instead in /home/user/app/vendor/facade/ignition/src/SolutionProviders/MergeConflictSolutionProvider.php:52
```

In php8.2 I got the previous error and it was solved by this commit.
I propose you guys to apply this change to prepare for php8.2 supoprt in the future.