### PR TITLE
Update psalm and add it to CI

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,56 @@
+name: Psalm
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.php'
+      - 'composer.*'
+      - 'psalm*'
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      # mtime needs to be restored for Psalm cache to work correctly
+      - name: Restore mtimes
+        uses: chetan/git-restore-mtime-action@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: |
+          echo "composer_dir={$(composer config cache-files-dir)}" >> $GITHUB_OUTPUT
+
+      - name: Retrieve Composer‘s cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.composer_dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install composer dependencies
+        run: "composer install --no-interaction --no-progress --no-scripts"
+
+      # the way cache keys are set up will always cause a cache miss
+      # but will restore the cache generated during the previous run based on partial match
+      - name: Retrieve Psalm’s cache
+        uses: actions/cache@v3
+        with:
+          path: ./cache/psalm
+          key: ${{ runner.os }}-psalm-cache-${{ hashFiles('psalm.xml.dist', 'psalm-baseline.xml', './composer.lock') }}
+
+      - name: Run Psalm
+        run: ./vendor/bin/psalm --find-unused-psalm-suppress --output-format=github

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "livewire/livewire": "^2.4",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^5.0|^6.0",
-        "psalm/plugin-laravel": "^1.2"
+        "psalm/plugin-laravel": "^2.0"
     },
     "suggest": {
         "laravel/telescope": "^3.1"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,50 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.17.1@8f211792d813e4dc89f04ed372785ce93b902fd1">
+<files psalm-version="5.5.0@b63061a27f2683ec0f3509012bb22daab3b65b61">
+  <file src="src/ErrorPage/IgnitionWhoopsHandler.php">
+    <UndefinedClass>
+      <code>Handler</code>
+    </UndefinedClass>
+  </file>
   <file src="src/IgnitionServiceProvider.php">
-    <UndefinedInterfaceMethod occurrences="7">
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-    </UndefinedInterfaceMethod>
+    <MissingDependency>
+      <code>IgnitionExceptionRenderer</code>
+      <code>IgnitionWhoopsHandler</code>
+    </MissingDependency>
   </file>
-  <file src="src/LogRecorder/LogRecorder.php">
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>$this-&gt;app</code>
-    </UndefinedInterfaceMethod>
-  </file>
-  <file src="src/QueryRecorder/QueryRecorder.php">
-    <UndefinedInterfaceMethod occurrences="3">
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-      <code>$this-&gt;app</code>
-    </UndefinedInterfaceMethod>
-  </file>
-  <file src="src/SolutionProviders/MissingLivewireComponentSolutionProvider.php">
-    <UndefinedClass occurrences="1">
-      <code>ComponentNotFoundException</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/SolutionProviders/UnknownValidationSolutionProvider.php">
-    <UndefinedClass occurrences="1">
-      <code>app('validator')</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Solutions/LivewireDiscoverSolution.php">
-    <UndefinedClass occurrences="1">
-      <code>LivewireComponentsFinder</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Views/Engines/CompilerEngine.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$baseException</code>
-    </ParamNameMismatch>
+  <file src="src/Support/LivewireComponentParser.php">
+    <ImplicitToStringCast>
+      <code>Str::of($reflectionMethod-&gt;name)-&gt;after('get')-&gt;before('Property')</code>
+    </ImplicitToStringCast>
   </file>
   <file src="src/Views/Engines/PhpEngine.php">
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$baseException</code>
     </ParamNameMismatch>
   </file>

--- a/src/Views/Engines/CompilerEngine.php
+++ b/src/Views/Engines/CompilerEngine.php
@@ -43,12 +43,13 @@ class CompilerEngine extends \Illuminate\View\Engines\CompilerEngine
      * @param \Throwable $baseException
      * @param int $obLevel
      *
-     * @return void
+     * @return never
      *
      * @throws \Throwable
      */
-    protected function handleViewException(Throwable $baseException, $obLevel)
+    protected function handleViewException(Throwable $e, $obLevel)
     {
+        $baseException = $e; // just to prevent any named params issues
         while (ob_get_level() > $obLevel) {
             ob_end_clean();
         }


### PR DESCRIPTION
psalm/plugin-laravel has been recently updated and together with new Psalm versions can detected more issues. Due to other dependencies, it's not possible to use the latest one version of the plugin, but even [v2.0.2](https://github.com/psalm/psalm-plugin-laravel/releases/tag/v2.0.2) works a way better